### PR TITLE
Updated to return the original acorn object

### DIFF
--- a/acorn-es7-plugin.js
+++ b/acorn-es7-plugin.js
@@ -238,4 +238,5 @@ function asyncAwaitPlugin (parser,options){
 
 module.exports = function(acorn) {
 	acorn.plugins.asyncawait = asyncAwaitPlugin ;
+	return acorn
 }


### PR DESCRIPTION
This way it can be used with other acorn plugins. ie.

```
var acornJSX = require('acorn-jsx/inject')
var acornES7 = require('acorn-es7-plugin')
var acornRaw = require('acorn');
var acorn = acornES7(acornJSX(rawAcorn));
```
