### PR TITLE
Issue 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,18 @@ When using the plugin, you can supply an object in place of the 'true' flag with
 
 | flag | meaning |
 |------|---------|
-| awaitAnywhere | If `await` is used outside of an async function and could not be an identifier, generate an AwaitExpression node. This typically means you can use `await` anywhere _except_ when its argument would require parentheses, as this parses to a call to 'await(....)'. |
+| awaitAnywhere | If `await` is used outside of an async function and could not be an identifier, generate an AwaitExpression node. This typically means you can use `await` anywhere _except_ when its argument would require parentheses, as this parses to a call to 'await(....)'. Should not be used with inAsyncFunction option |
+| inAsyncFunction | Parse the code as if it is the body of an `async function`. This means `await` cannot be an identifier and is always an AwaitExpression, even if the argument is parenthesized. Should not be used with the awaitAnywhere option |
 | asyncExits | Allow the additional sequences `async return <optional-expression>` and `async throw <expression>`. These sequences are used with [nodent](https://github.com/MatAtBread/nodent). In each case, as with async functions, a standard ReturnStatement (or ThrowStatement) node is generated, with an additional member 'async' set to true.
 
 Changelog
 =========
-03-May-16: v1.0.13 
+03-May-16: v1.0.14
+
+- Correctly parse async statements containing comments.
+- Implement the option inAsyncFunction
+
+03-May-16: v1.0.13
 
 - Correctly parse the statement `export async function name(){...}` as _async function name(){...}_ is a valid named declaration.
 

--- a/acorn-es7-plugin.js
+++ b/acorn-es7-plugin.js
@@ -2,7 +2,7 @@ var NotAsync = {} ;
 var asyncExit = /^async[\t ]+(return|throw)/ ;
 var asyncFunction = /^async[\t ]+function/ ;
 var atomOrPropertyOrLabel = /^\s*[):;]/ ;
-var removeComments = /([^\n])\/\*(\*(?!\/)|[^*])*\*\/([^\n])/g ;
+var removeComments = /([^\n])\/\*(\*(?!\/)|[^\n*])*\*\/([^\n])/g ;
 
 function hasLineTerminatorBeforeNext(st, since) {
 	return st.lineStart >= since;
@@ -10,11 +10,9 @@ function hasLineTerminatorBeforeNext(st, since) {
 
 function test(regex,st,noComment) {
 	var src = st.input.slice(st.start) ;
-//  console.log(src.match(removeComments)) ;
 	if (noComment) {
 		src = src.replace(removeComments,"$1 $3") ;
-//		console.log(src) ;
-	}
+  }
 	return regex.test(src);
 }
 
@@ -63,6 +61,9 @@ function asyncAwaitPlugin (parser,options){
       this.reservedWordsStrict = new RegExp(this.reservedWordsStrict.toString().replace(/await|async/g,"").replace("|/","/").replace("/|","/").replace("||","|")) ;
       this.reservedWordsStrictBind = new RegExp(this.reservedWordsStrictBind.toString().replace(/await|async/g,"").replace("|/","/").replace("/|","/").replace("||","|")) ;
 			this.inAsyncFunction = options.inAsyncFunction ;
+			if (options.awaitAnywhere && options.inAsyncFunction)
+				parser.raise(node.start,"The options awaitAnywhere and inAsyncFunction are mutually exclusive") ;
+
 			return base.apply(this,arguments);
 		}
 	}) ;

--- a/acorn-es7-plugin.js
+++ b/acorn-es7-plugin.js
@@ -2,14 +2,20 @@ var NotAsync = {} ;
 var asyncExit = /^async[\t ]+(return|throw)/ ;
 var asyncFunction = /^async[\t ]+function/ ;
 var atomOrPropertyOrLabel = /^\s*[):;]/ ;
-var removeComments = /\/\*(\*(?!\/)|[^*])*\*\/|\/\/.*/g ;
+var removeComments = /([^\n])\/\*(\*(?!\/)|[^*])*\*\/([^\n])/g ;
 
 function hasLineTerminatorBeforeNext(st, since) {
 	return st.lineStart >= since;
 }
 
-function test(regex,st) {
-	return regex.test(st.input.slice(st.start).replace(removeComments," "));
+function test(regex,st,noComment) {
+	var src = st.input.slice(st.start) ;
+//  console.log(src.match(removeComments)) ;
+	if (noComment) {
+		src = src.replace(removeComments,"$1 $3") ;
+//		console.log(src) ;
+	}
+	return regex.test(src);
 }
 
 /* Return the object holding the parser's 'State'. This is different between acorn ('this')
@@ -76,13 +82,13 @@ function asyncAwaitPlugin (parser,options){
 			var start = st.start;
 			var startLoc = st.startLoc;
 			if (st.type.label==='name') {
-				if (test(asyncFunction,st)) {
+				if (test(asyncFunction,st,true)) {
 					var wasAsync = st.inAsyncFunction ;
 					try {
 						st.inAsyncFunction = true ;
 						this.next() ;
 						var r = this.parseStatement(declaration, topLevel) ;
-						r.async = true ;
+ 						r.async = true ;
 						r.start = start;
 						r.loc && (r.loc.start = startLoc);
 						return r ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acorn-es7-plugin",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "A plugin for the Acorn parser that understands the ES7 keywords async and await",
   "main": "acorn-es7-plugin.js",
   "scripts": {

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "Tests for acorn-es7-plugin",
   "main": "nothing-here",
   "scripts": {
-    "test": "node test-es5.js ; mocha --opts ./mocha.opts"
+    "test": "mocha --opts ./mocha.opts ; node test-es5.js "
   },
   "repository": {
     "type": "git",

--- a/test/test-es5.js
+++ b/test/test-es5.js
@@ -1,20 +1,20 @@
 'use strict';
-
 /* Simple test script that doesn't need mocha or similar - it just parses stuff and checks the returned AST */
 var acorn = require('acorn');
 var colors = require('colors');
 require('../')(acorn);
-
 function parse(code, pluginOptions) {
-  if (Array.isArray(code)) {
-    code = code.join('\n');
-  }
-  return acorn.parse(code, {
-      sourceType: 'module',
-      ecmaVersion: 7,
-      locations: true,
-      ranges: true,
-      plugins: {asyncawait: pluginOptions || {}}
+    if (Array.isArray(code)) {
+        code = code.join('\n');
+    }
+    return acorn.parse(code, {
+        sourceType: 'module',
+        ecmaVersion: 7,
+        locations: true,
+        ranges: true,
+        plugins: {
+            asyncawait: pluginOptions || {}
+        }
     });
 }
 
@@ -26,47 +26,86 @@ function isAsyncFnDecl(ast) {
     return ast.body[0].async === true && ast.body[0].type == "FunctionDeclaration";
 }
 
-var tests = [
-       {desc:"Simple async function",code:"async function x() { return undefined; }",
-           pass:function(ast){ return ast.body[0].async===true}
-       },
-       {desc:"Await in async is AwaitExpression",code:"async function x() { await(undefined); await undefined ; }",
-           pass:function(ast){ return ast.body[0].body.body[0].expression.type==='AwaitExpression' && ast.body[0].body.body[1].expression.type==='AwaitExpression'}
-       },
-       {desc:"Await in function is identifier",code:"function x() { await(undefined); }",
-           pass:function(ast){ return ast.body[0].body.body[0].expression.callee.name==='await'}
-       },
-       {desc:"Async method",code:"var a = {async x(){}}",
-           pass:function(ast){ return ast.body[0].declarations[0].init.properties[0].value.async }
-       },
-       {desc:"Async get method",code:"var a = {async get x(){}}",
-           pass:function(ast){ return ast.body[0].declarations[0].init.properties[0].value.async }
-       },
-       {desc:"Async arrow",code:"var a = async()=>0",
-           pass:function(ast){ return ast.body[0].declarations[0].init.async }
-       },
-       {desc:"Async set method fails",code:"var a = {async set x(){}}",
-           pass:function(ex){ return ex === "'set <member>(value)' cannot be be async (1:15)" }
-       },
-       {desc:"Async constructor fails",code:"var a = {async constructor(){}}",
-           pass:function(ex){ return ex === "'constructor()' cannot be be async (1:15)" }
-       },
-       {desc:"Await declaration fails in async function",code:"async function x() { var await; }",
-           pass:function(ex){ return ex === "'await' is reserved within async functions (1:25)" }
-       },
-       {desc:"Await function declaration fails in async function",code:"async function x() { function await() {} }",
-           pass:function(ex){ return ex === "'await' is reserved within async functions (1:30)" }
-       },
-       {desc:"Await reference fails in async function",code:"async function x() { return 1+await; }",
-           pass:function(ex){ return ex === "Unexpected token (1:35)" }
- },{
+function isExprType(type) {
+    return function (ast) {
+        return ast.body[0].type === 'ExpressionStatement' && ast.body[0].expression.type === type;
+    };
+}
+
+var tests = [{
+    desc: "Simple async function",
+    code: "async function x() { return undefined; }",
+    pass: function (ast) {
+        return ast.body[0].async === true;
+    }
+},{
+    desc: "Await in async is AwaitExpression",
+    code: "async function x() { await(undefined); await undefined ; }",
+    pass: function (ast) {
+        return ast.body[0].body.body[0].expression.type === 'AwaitExpression' && ast.body[0].body.body[1].expression.type === 'AwaitExpression';
+    }
+},{
+    desc: "Await in function is identifier",
+    code: "function x() { await(undefined); }",
+    pass: function (ast) {
+        return ast.body[0].body.body[0].expression.callee.name === 'await';
+    }
+},{
+    desc: "Async method",
+    code: "var a = {async x(){}}",
+    pass: function (ast) {
+        return ast.body[0].declarations[0].init.properties[0].value.async;
+    }
+},{
+    desc: "Async get method",
+    code: "var a = {async get x(){}}",
+    pass: function (ast) {
+        return ast.body[0].declarations[0].init.properties[0].value.async;
+    }
+},{
+    desc: "Async arrow",
+    code: "var a = async()=>0",
+    pass: function (ast) {
+        return ast.body[0].declarations[0].init.async;
+    }
+},{
+    desc: "Async set method fails",
+    code: "var a = {async set x(){}}",
+    pass: function (ex) {
+        return ex === "'set <member>(value)' cannot be be async (1:15)";
+    }
+},{
+    desc: "Async constructor fails",
+    code: "var a = {async constructor(){}}",
+    pass: function (ex) {
+        return ex === "'constructor()' cannot be be async (1:15)";
+    }
+},{
+    desc: "Await declaration fails in async function",
+    code: "async function x() { var await; }",
+    pass: function (ex) {
+        return ex === "'await' is reserved within async functions (1:25)";
+    }
+},{
+    desc: "Await function declaration fails in async function",
+    code: "async function x() { function await() {} }",
+    pass: function (ex) {
+        return ex === "'await' is reserved within async functions (1:30)";
+    }
+},{
+    desc: "Await reference fails in async function",
+    code: "async function x() { return 1+await; }",
+    pass: function (ex) {
+        return ex === "Unexpected token (1:35)";
+    }
+},{
     desc: "{code} is an async FunctionDeclaration",
     code: "async /* a */ function x(){}",
     pass: isAsyncFnDecl
 },{
-    desc: "{code} is an async FunctionDeclaration",
+    desc: "{code} is a reference to 'async' and a sync FunctionDeclaration",
     code: "async /*\n*/function x(){}",
-    pass: isAsyncFnDecl
+    pass: isIdentThenFnDecl
 },{
     desc: "{code} is a reference to 'async' and a sync FunctionDeclaration",
     code: "async /* a */\nfunction x(){}",
@@ -84,39 +123,76 @@ var tests = [
     code: "async /*\n*/\nfunction x(){}",
     pass: isIdentThenFnDecl
 },{
+    /* Valid combinations of await options; none, just inAsyncFunction, or just awaitAnywhere */
     desc: "{code} is an AwaitExpression when inAsyncFunction option is true",
     code: "await(x)",
-    options: { inAsyncFunction: true },
-    pass: function (ast) {
-        return ast.body[0].type === 'ExpressionStatement' && ast.body[0].expression.type === 'AwaitExpression' ;
-    }},
-    {
-      desc: "{code} is an CallExpression when inAsyncFunction option is false",
-        code: "await(x)",
-        pass: function (ast) {
-            return ast.body[0].type === 'ExpressionStatement' && ast.body[0].expression.type === 'CallExpression' ;
-        }
-      }
-] ;
-
+    options: {
+        inAsyncFunction: true
+    },
+    pass: isExprType('AwaitExpression')
+},{
+    desc: "{code} is an AwaitExpression when inAsyncFunction option is true",
+    code: "await x",
+    options: {
+        inAsyncFunction: true
+    },
+    pass: isExprType('AwaitExpression')
+},{
+    desc: "{code} is a CallExpression when awaitAnywhere option is true",
+    code: "await(x)",
+    options: {
+        awaitAnywhere: true
+    },
+    pass: isExprType('CallExpression')
+},{
+    desc: "{code} is an AwaitExpression when awaitAnywhere option is true",
+    code: "await x",
+    options: {
+        awaitAnywhere: true
+    },
+    pass: isExprType('AwaitExpression')
+},{
+    desc: "{code} is a CallExpression when inAsyncFunction and awaitAnywhere option are false",
+    code: "await(x)",
+    pass: isExprType('CallExpression')
+},{
+    desc: "{code} is a SyntaxError when inAsyncFunction and awaitAnywhere option are false",
+    code: "await x",
+    pass: function (ex) {
+        return ex === "Unexpected token (1:6)";
+    }
+}];
 var out = {
-  true:"pass".green,
-  false:"fail".red
+    true: "pass".green,
+    false: "fail".red
 };
-
 var testNumber = +process.argv[2] || 0;
 if (testNumber) {
-    tests = [tests[testNumber-1]] ;
+    tests = [tests[testNumber - 1]];
 } else {
-  testNumber +=1 ;
+    testNumber += 1;
 }
-
-tests.forEach(function(test,idx){
-  var code = test.code.replace(/\n/g,' <linefeed> ') ;
-  var desc = test.desc.replace('{code}',code.yellow) ;
+var results = {
+    true: 0,
+    false: 0
+};
+tests.forEach(function (test, idx) {
+    var code = test.code.replace(/\n/g, ' <linefeed> ');
+    var desc = test.desc.replace('{code}', code.yellow);
+    var pass = function () {
+        var p = test.pass.apply(this, arguments);
+        results[p] += 1;
+        return p;
+    };
     try {
-        console.log((idx+testNumber)+")\t",desc,out[test.pass(parse(test.code,test.options))]);
-    } catch(ex) {
-        console.log((idx+testNumber)+")\t",desc,ex.message.cyan,out[test.pass(ex.message)]);
+        console.log(idx + testNumber + ")\t", desc, out[pass(parse(test.code, test.options))]);
+    } catch (ex) {
+        console.log(idx + testNumber + ")\t", desc, ex.message.cyan, out[pass(ex.message)]);
     }
-}) ;
+});
+console.log('');
+if (results.true) 
+    console.log((results.true + " of " + tests.length + " tests passed").green);
+if (results.false) 
+    console.log((results.false + " of " + tests.length + " tests failed").red);
+

--- a/test/test.js
+++ b/test/test.js
@@ -161,13 +161,13 @@ describe('async', () => {
         ]);
       });
 
-/*      it('finds Identifier ExpressionStatement', () => {
+      it('finds Identifier ExpressionStatement', () => {
         assertFindsIdentifierExpressionStatement(ast);
-      });*/
+      });
 
       it('does not mark FunctionDeclaration as async', () => {
         node = find('FunctionDeclaration', ast);
-        assert(node.async, 'Expected node.async to be true');
+        assert(!node.async, 'Expected node.async to be false');
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -151,7 +151,7 @@ describe('async', () => {
       });
     });
 
-    describe('linefeed after async (multiline comment)', () => {
+    describe('linefeed after async (multiline comment) function', () => {
       var ast;
       beforeEach(() => {
         ast = parse([
@@ -161,13 +161,13 @@ describe('async', () => {
         ]);
       });
 
-      it('finds Identifier ExpressionStatement', () => {
+/*      it('finds Identifier ExpressionStatement', () => {
         assertFindsIdentifierExpressionStatement(ast);
-      });
+      });*/
 
       it('does not mark FunctionDeclaration as async', () => {
         node = find('FunctionDeclaration', ast);
-        assert(!node.async, 'Expected node.async to be false');
+        assert(node.async, 'Expected node.async to be true');
       });
     });
   });
@@ -271,7 +271,7 @@ describe('async', () => {
       });
     });
 
-    describe('linefeed after async (multiline comment)', () => {
+    describe('linefeed after async (multiline comment), function', () => {
       var ast;
       beforeEach(() => {
         ast = parse([
@@ -346,7 +346,7 @@ describe('async', () => {
           'var x = {',
           '  async \t\t  ',
           '  foo() {}',
-          '};'      
+          '};'
         ]));
       });
     });
@@ -362,7 +362,7 @@ describe('async', () => {
       });
     });
 
-    describe('linefeed after async (multiline comment)', () => {
+    describe('linefeed after async (multiline comment) illegal decl', () => {
       it('finds Identifier ExpressionStatement', () => {
         assert.throws(() => parse([
           'var x = {',
@@ -479,7 +479,7 @@ describe('async', () => {
       });
     });
 
-    describe('linefeed after async (multiline comment)', () => {
+    describe('linefeed after async (multiline comment) arrow decl', () => {
       var ast;
       beforeEach(() => {
         ast = parse([


### PR DESCRIPTION
Merged https://github.com/MatAtBread/acorn-es7-plugin/pull/8 by hand (thanks @caitp)
Closes https://github.com/MatAtBread/acorn-es7-plugin/issues/7
Closes https://github.com/MatAtBread/acorn-es7-plugin/issues/9

Added option: `inAsyncFunction` - assumes the code to be parsed is inside an async function. cf `awaitAnywhere` (see https://github.com/MatAtBread/acorn-es7-plugin/blob/issue-10/README.md#changelog for details)
